### PR TITLE
fix(index): Fix cart route display text

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -43,7 +43,7 @@
         </td>
         <td>
             <a href="/cart/U10000">
-                /user/:owner
+                /cart/:owner
             </a>
         </td>
         <td>


### PR DESCRIPTION
The index page was displaying `/user/:owner` as the route template when it should be `/cart/:owner`